### PR TITLE
Issue 126: h5pywriter.shape returns () for SCALAR attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2021-02-12 Jan Kotanski <jankotan@gmail.com>
+	* h5pywriter.shape returns () for SCALAR attributes
+	* tagged as v3.0.1
+
+2021-02-12 Jan Kotanski <jankotan@gmail.com>
 	* store strings as SCALAR by default
 	* remove support for pni
 	* h5*writer.shape returns () for SCALAR fields

--- a/nxstools/h5pywriter.py
+++ b/nxstools/h5pywriter.py
@@ -1254,9 +1254,9 @@ class H5PYAttribute(filewriter.FTAttribute):
         :rtype: :obj:`list` < :obj:`int` >
         """
         if hasattr(self._h5object[0][self.name], "shape"):
-            return self._h5object[0][self.name].shape or (1,)
+            return self._h5object[0][self.name].shape
         else:
-            return (1,)
+            return ()
 
     def reopen(self):
         """ reopen attribute

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -20,4 +20,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/test/FileWriterH5CppH5PY_test.py
+++ b/test/FileWriterH5CppH5PY_test.py
@@ -5446,7 +5446,7 @@ class FileWriterH5CppH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -5598,7 +5598,7 @@ class FileWriterH5CppH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -7060,7 +7060,7 @@ class FileWriterH5CppH5PYTest(unittest.TestCase):
             self.assertEqual(atintscalar.name, 'atintscalar')
             self.assertEqual(atintscalar.path, '/@atintscalar')
             self.assertEqual(atintscalar.dtype, 'int64')
-            self.assertEqual(atintscalar.shape, (1,))
+            self.assertEqual(atintscalar.shape, ())
             self.assertEqual(atintscalar.is_valid, True)
             self.assertEqual(atintscalar.read(), itvl[0])
             self.assertEqual(atintscalar[...], itvl[0])
@@ -7097,7 +7097,7 @@ class FileWriterH5CppH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), stvl[0])
             self.assertEqual(atstrscalar[...], stvl[0])
@@ -7131,7 +7131,7 @@ class FileWriterH5CppH5PYTest(unittest.TestCase):
             self.assertEqual(atfloatscalar.path,
                              '/entry12345:NXentry/intscalar@atfloatscalar')
             self.assertEqual(atfloatscalar.dtype, 'float64')
-            self.assertEqual(atfloatscalar.shape, (1,))
+            self.assertEqual(atfloatscalar.shape, ())
             self.assertEqual(atfloatscalar.is_valid, True)
             self.assertEqual(atfloatscalar.read(), flvl[0])
             self.assertEqual(atfloatscalar[...], flvl[0])

--- a/test/FileWriterH5PY_test.py
+++ b/test/FileWriterH5PY_test.py
@@ -2787,7 +2787,7 @@ class FileWriterH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -2939,7 +2939,7 @@ class FileWriterH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -3238,7 +3238,7 @@ class FileWriterH5PYTest(unittest.TestCase):
             self.assertEqual(atintscalar.name, 'atintscalar')
             self.assertEqual(atintscalar.path, '/@atintscalar')
             self.assertEqual(atintscalar.dtype, 'int64')
-            self.assertEqual(atintscalar.shape, (1,))
+            self.assertEqual(atintscalar.shape, ())
             self.assertEqual(atintscalar.is_valid, True)
             self.assertEqual(atintscalar.read(), itvl[0])
             self.assertEqual(atintscalar[...], itvl[0])
@@ -3275,7 +3275,7 @@ class FileWriterH5PYTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), stvl[0])
             self.assertEqual(atstrscalar[...], stvl[0])
@@ -3309,7 +3309,7 @@ class FileWriterH5PYTest(unittest.TestCase):
             self.assertEqual(atfloatscalar.path,
                              '/entry12345:NXentry/intscalar@atfloatscalar')
             self.assertEqual(atfloatscalar.dtype, 'float64')
-            self.assertEqual(atfloatscalar.shape, (1,))
+            self.assertEqual(atfloatscalar.shape, ())
             self.assertEqual(atfloatscalar.is_valid, True)
             self.assertEqual(atfloatscalar.read(), flvl[0])
             self.assertEqual(atfloatscalar[...], flvl[0])

--- a/test/H5PYWriter_test.py
+++ b/test/H5PYWriter_test.py
@@ -2571,7 +2571,7 @@ class H5PYWriterTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -2722,7 +2722,7 @@ class H5PYWriterTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), '')
             self.assertEqual(atstrscalar[...], '')
@@ -2998,7 +2998,7 @@ class H5PYWriterTest(unittest.TestCase):
             self.assertEqual(atintscalar.name, 'atintscalar')
             self.assertEqual(atintscalar.path, '/@atintscalar')
             self.assertEqual(atintscalar.dtype, 'int64')
-            self.assertEqual(atintscalar.shape, (1,))
+            self.assertEqual(atintscalar.shape, ())
             self.assertEqual(atintscalar.is_valid, True)
             self.assertEqual(atintscalar.read(), itvl[0])
             self.assertEqual(atintscalar[...], itvl[0])
@@ -3035,7 +3035,7 @@ class H5PYWriterTest(unittest.TestCase):
             self.assertEqual(
                 atstrscalar.path, '/entry12345:NXentry@atstrscalar')
             self.assertEqual(atstrscalar.dtype, 'string')
-            self.assertEqual(atstrscalar.shape, (1,))
+            self.assertEqual(atstrscalar.shape, ())
             self.assertEqual(atstrscalar.is_valid, True)
             self.assertEqual(atstrscalar.read(), stvl[0])
             self.assertEqual(atstrscalar[...], stvl[0])
@@ -3069,7 +3069,7 @@ class H5PYWriterTest(unittest.TestCase):
             self.assertEqual(atfloatscalar.path,
                              '/entry12345:NXentry/intscalar@atfloatscalar')
             self.assertEqual(atfloatscalar.dtype, 'float64')
-            self.assertEqual(atfloatscalar.shape, (1,))
+            self.assertEqual(atfloatscalar.shape, ())
             self.assertEqual(atfloatscalar.is_valid, True)
             self.assertEqual(atfloatscalar.read(), flvl[0])
             self.assertEqual(atfloatscalar[...], flvl[0])


### PR DESCRIPTION
It resolves #126