### PR TITLE
Issue 137: add checks for duplicated sardana names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-04-14 Jan Kotanski <jankotan@gmail.com>
+	* add checks for duplicated sardana names
+	* add dalsa template component
+	* tagged as v3.3.0
+
 2021-04-07 Jan Kotanski <jankotan@gmail.com>
 	* add support got h5py >= 3.0.0
 	* add nxscollect vds command line tool

--- a/nxstools/nxscreate.py
+++ b/nxstools/nxscreate.py
@@ -1295,11 +1295,26 @@ class ClientDS(Runner):
             sys.exit(255)
 
 
+def _supportoldcommands():
+    """ replace the old command names to the new ones
+    """
+
+    oldnew = {
+        'compare': 'cmp_onlinexml',
+    }
+
+    if sys.argv and len(sys.argv) > 1:
+        if sys.argv[1] in oldnew.keys():
+            sys.argv[1] = oldnew[sys.argv[1]]
+
+
 def main():
     """ the main program function
     """
     description = " Command-line tool for creating NXSConfigServer" \
                   + " configuration of Nexus Files"
+
+    # _supportoldcommands()
 
     epilog = 'For more help:\n  nxscreate <sub-command> -h'
     parser = NXSArgParser(

--- a/nxstools/nxscreator.py
+++ b/nxstools/nxscreator.py
@@ -1434,8 +1434,8 @@ class CompareOnlineDS(object):
                 dv.sardanahostname = self._getChildText(
                     device, "sardanahostname")
                 if name not in dct.keys():
-                    dct[name] = []
-                dct[name].append(dv)
+                    dct[dv.sardananame or name] = []
+                dct[dv.sardananame or name].append(dv)
         return dct
 
     def compare(self):

--- a/nxstools/nxscreator.py
+++ b/nxstools/nxscreator.py
@@ -1446,13 +1446,13 @@ class CompareOnlineDS(object):
         common = sorted(set(dct1.keys()) & set(dct2.keys()))
         d1md2 = sorted(set(dct1.keys()) - set(dct2.keys()))
         d2md1 = sorted(set(dct2.keys()) - set(dct1.keys()))
-        addd1 = dict((str(k), [(str(dv.sardananame)
-                                if dv.sardananame else dv.sardananame)
-                               for dv in dct1[k]])
+        addd1 = dict((str(k),
+                      [(str(dv.name) if dv.name else dv.name)
+                       for dv in dct1[k]])
                      for k in d1md2)
-        addd2 = dict((str(k), [(str(dv.sardananame)
-                                if dv.sardananame else dv.sardananame)
-                               for dv in dct2[k]])
+        addd2 = dict((str(k),
+                      [(str(dv.name) if dv.name else dv.name)
+                       for dv in dct2[k]])
                      for k in d2md1)
         diff = {}
         for name in common:
@@ -1474,15 +1474,13 @@ class CompareOnlineDS(object):
                 for i1, dv in enumerate(dct1[name]):
                     if l1[i1]:
                         addd1[str(name)].append(
-                            str(dv.sardananame)
-                            if dv.sardananame else dv.sardananame)
+                            (str(dv.name) if dv.name else dv.name))
             elif True not in l1 and True in l2:
                 addd2[str(name)] = []
                 for i2, dv in enumerate(dct2[name]):
                     if l2[i2]:
                         addd2[str(name)].append(
-                            str(dv.sardananame)
-                            if dv.sardananame else dv.sardananame)
+                            (str(dv.name) if dv.name else dv.name))
             if True in l1 or True in l2:
                 diff[str(name)] = []
                 for i1, dv1 in enumerate(dct1[name]):
@@ -1492,9 +1490,11 @@ class CompareOnlineDS(object):
 
         if self._printouts:
             import pprint
-            print("Additional devices in file1 {name: sardananame} :\n")
+            print("Additional devices in '%s' {alias: [name]} :\n"
+                  % self.args[0])
             pprint.pprint(addd1)
-            print("\nAdditional devices in file2 {name: sardananame} :\n")
+            print("\nAdditional devices in '%s' {alias: [name]} :\n"
+                  % self.args[1])
             pprint.pprint(addd2)
             print("\nDiffrences in the common part:\n")
             pprint.pprint(diff)

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -20,4 +20,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/test/NXSCreateCompare_test.py
+++ b/test/NXSCreateCompare_test.py
@@ -233,10 +233,12 @@ class NXSCreateCompareTest(unittest.TestCase):
                 self.assertEqual(lines[13], "")
                 self.assertTrue(
                     lines[2].startswith(
-                        "Additional devices in file1 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname))
                 self.assertTrue(
                     lines[6].startswith(
-                        "Additional devices in file2 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname))
                 self.assertTrue(
                     lines[10].startswith(
                         "Diffrences in the common part:"))
@@ -391,10 +393,12 @@ class NXSCreateCompareTest(unittest.TestCase):
                 self.assertTrue(lines[0].startswith("Comparing:"))
                 self.assertTrue(
                     lines[1].startswith(
-                        "Additional devices in file1 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname1))
                 self.assertTrue(
                     lines[3].startswith(
-                        "Additional devices in file2 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname2))
                 self.assertTrue(
                     lines[5].startswith(
                         "Diffrences in the common part:"))
@@ -403,12 +407,17 @@ class NXSCreateCompareTest(unittest.TestCase):
                 second = eval(lines[4])
                 common = eval(lines[6])
                 self.myAssertDict(
-                    first, {'my_test_vfcadc': [None]})
+                    first,
+                    {'mot01': ['my_exp_mot01'],
+                     'my_test_vfcadc': ['my_test_vfcadc']}
+                )
                 self.myAssertDict(
                     second,
-                    {'my_test_tip850adc': [None],
-                     'my_test_tip830': [None],
-                     'my_test_tip850dac': [None]})
+                    {'mot_01': ['my_exp_mot01'],
+                     'my_test_tip830': ['my_test_tip830'],
+                     'my_test_tip850adc': ['my_test_tip850adc'],
+                     'my_test_tip850dac': ['my_test_tip850dac']}
+                )
                 self.myAssertDict(
                     common,
                     {
@@ -421,9 +430,6 @@ class NXSCreateCompareTest(unittest.TestCase):
                                 ('p09/motor/exp.04', 'p09/motor/exp.02')
                             }
                         ],
-                        'my_exp_mot01': [
-                            {'sardananame': ('mot01', 'mot_01')}
-                        ]
                     }
                 )
 
@@ -491,7 +497,7 @@ class NXSCreateCompareTest(unittest.TestCase):
         xml2 = """<?xml version="1.0"?>
 <hw>
 <device>
- <name>my_exp_mot01</name>
+ <name>my_exp_mot_01</name>
  <type>stepping_motor</type>
  <module>oms58</module>
  <device>p09/Motor/exp.01</device>
@@ -500,7 +506,7 @@ class NXSCreateCompareTest(unittest.TestCase):
  <controller>oms58_exp</controller>
  <channel>1</channel>
  <rootdevicename>p09/motor/exp</rootdevicename>
- <sardananame>mot_01</sardananame>
+ <sardananame>mot01</sardananame>
 </device>
 <device>
  <name>my_exp_mot02</name>
@@ -572,10 +578,12 @@ class NXSCreateCompareTest(unittest.TestCase):
                 self.assertTrue(lines[0].startswith("Comparing:"))
                 self.assertTrue(
                     lines[1].startswith(
-                        "Additional devices in file1 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname1))
                 self.assertTrue(
                     lines[3].startswith(
-                        "Additional devices in file2 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname2))
                 self.assertTrue(
                     lines[5].startswith(
                         "Diffrences in the common part:"))
@@ -584,17 +592,18 @@ class NXSCreateCompareTest(unittest.TestCase):
                 second = eval(lines[4])
                 common = eval(lines[6])
                 self.myAssertDict(
-                    first, {'my_test_vfcadc': [None]})
+                    first,
+                    {'my_test_vfcadc': ['my_test_vfcadc']})
                 self.myAssertDict(
                     second,
-                    {'my_test_tip850adc': [None],
-                     'my_test_tip830': [None],
-                     'my_test_tip850dac': [None]})
+                    {'my_test_tip830': ['my_test_tip830'],
+                     'my_test_tip850adc': ['my_test_tip850adc'],
+                     'my_test_tip850dac': ['my_test_tip850dac']})
                 self.myAssertDict(
                     common,
-                    {'my_exp_mot01':
-                     [{'sardananame': ('mot01', 'mot_01'),
-                       'tdevice': ('P09/motor/exp.01', 'p09/Motor/exp.01')}],
+                    {'mot01': [{'name': ('my_exp_mot01', 'my_exp_mot_01'),
+                                'tdevice':
+                                ('P09/motor/exp.01', 'p09/Motor/exp.01')}],
                      'my_exp_mot02':
                      [{'tdevice': ('P09/motor/exp.04', 'p09/motor/Exp.02')}],
                      'my_exp_mot03':
@@ -751,10 +760,12 @@ class NXSCreateCompareTest(unittest.TestCase):
                 self.assertTrue(lines[0].startswith("Comparing:"))
                 self.assertTrue(
                     lines[1].startswith(
-                        "Additional devices in file1 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname1))
                 self.assertTrue(
                     lines[3].startswith(
-                        "Additional devices in file2 {name: sardananame} :"))
+                        "Additional devices in '%s' {alias: [name]} :"
+                        % fname2))
                 self.assertTrue(
                     lines[5].startswith(
                         "Diffrences in the common part:"))
@@ -764,14 +775,16 @@ class NXSCreateCompareTest(unittest.TestCase):
                 common = eval(lines[6])
                 self.myAssertDict(
                     first,
-                    {'My_exp_mot01': ['mot01'], 'my_test_vfcadc': [None]}
+                    {'mot01': ['My_exp_mot01'],
+                     'my_test_vfcadc': ['my_test_vfcadc']}
                 )
                 self.myAssertDict(
                     second,
-                    {'My_test_tip850adc': [None],
-                     'my_exp_mot01': ['mot_01'],
-                     'my_test_tip830': [None],
-                     'my_test_tip850dac': [None]})
+                    {'My_test_tip850adc': ['My_test_tip850adc'],
+                     'mot_01': ['my_exp_mot01'],
+                     'my_test_tip830': ['my_test_tip830'],
+                     'my_test_tip850dac': ['my_test_tip850dac']}
+                    )
                 self.myAssertDict(
                     common,
                     {'my_exp_mot02':


### PR DESCRIPTION
It resolves #137 by using the sardananame if exists as a key for dictionary to compare