### PR TITLE
read timezone from tzlocal if pytz  fails

### DIFF
--- a/nxstools/filewriter.py
+++ b/nxstools/filewriter.py
@@ -522,7 +522,11 @@ class FTFile(FTObject):
         :rtype: :obj:`str`
         """
         tzone = time.tzname[0]
-        tz = pytz.timezone(tzone)
+        try:
+            tz = pytz.timezone(tzone)
+        except Exception:
+            import tzlocal
+            tz = tzlocal.get_localzone()
         fmt = '%Y-%m-%dT%H:%M:%S.%f%z'
         starttime = tz.localize(datetime.datetime.now())
         return str(starttime.strftime(fmt))


### PR DESCRIPTION
It reads the timezone from tzlocal if pytz  fails as it was proposed in #223 