### PR TITLE
Issue 241: add --hidden-attributes to nxsfileinfo metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-02-25 Jan Kotanski <jankotan@gmail.com>
+	* print all attributes by nxsfileinfo metadata as default
+	* add --hidden-attributes option for nxsfileinfo metadata
+	* fixes for nxsfileinfo metadata subcommand
+	* tagged as v3.13.0
+
 2022-02-16 Jan Kotanski <jankotan@gmail.com>
 	* add nxsfileinfo metadata subcommand
 	* tagged as v3.12.0

--- a/doc/nxsfileinfo.rst
+++ b/doc/nxsfileinfo.rst
@@ -92,8 +92,9 @@ Synopsis
 Options:
    -h, --help            show this help message and exit
    -a ATTRS, --attributes ATTRS
-                        names of field or group attributes to be show (separated by commas without spaces). The default:
-                        'units,source_name,source_type,source,strategy,type,depends_on,transformation_type,vector,offset,NX_class,short_name'
+                        names of field or group attributes to be show (separated by commas without spaces). The default takes all attributes
+   -n NATTRS, --hidden-attributes NATTRS
+                        names of field or group attributes to be hidden (separated by commas without spaces). The default: 'nexdatas_source,nexdatas_strategy'
    -v VALUES, --values VALUES
                         field names of more dimensional datasets which value should be shown (separated by commas without spaces)
    -p GROUP_POSTFIX, --group-postfix GROUP_POSTFIX

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -311,10 +311,14 @@ class Metadata(Runner):
             "-a", "--attributes",
             help="names of field or group attributes to be show "
             " (separated by commas without spaces). "
-            "The  default: 'units,source_name,source_type,source,strategy,"
-            "type,depends_on,transformation_type,vector,offset,"
-            "NX_class,short_name'",
-            dest="attrs", default="")
+            "The  default takes all attributes",
+            dest="attrs", default=None)
+        self._parser.add_argument(
+            "-n", "--hidden-attributes",
+            help="names of field or group attributes to be hidden "
+            " (separated by commas without spaces). "
+            "The  default: 'nexdatas_source,nexdatas_strategy'",
+            dest="nattrs", default="nexdatas_source,nexdatas_strategy")
         self._parser.add_argument(
             "-v", "--values",
             help="field names of more dimensional datasets"
@@ -404,8 +408,17 @@ class Metadata(Runner):
 
         if options.values:
             values = options.values.split(',')
+
         if options.attrs:
             attrs = options.attrs.split(',')
+        elif options.attrs is not None:
+            attrs = []
+
+        if options.nattrs:
+            nattrs = options.nattrs.split(',')
+        else:
+            nattrs = []
+
         if options.entryclasses:
             entryclasses = options.entryclasses.split(',')
 
@@ -414,8 +427,8 @@ class Metadata(Runner):
         nxsparser.group_postfix = options.group_postfix
         nxsparser.entryclasses = entryclasses
         nxsparser.scientific = options.scientific
-        if attrs is not None:
-            nxsparser.attrs = attrs
+        nxsparser.attrs = attrs
+        nxsparser.hiddenattrs = nattrs
         nxsparser.parseMeta()
 
         try:

--- a/nxstools/nxsfileparser.py
+++ b/nxstools/nxsfileparser.py
@@ -438,18 +438,19 @@ class NXSFileParser(object):
             if (node.name in self.valuestostore and node.is_valid) \
                or "shape" not in desc \
                or desc["shape"] in [None, [1], []]:
-                vl = node.read()
-                cont = True
-                while cont:
-                    try:
-                        if not isinstance(vl, str) and \
-                           (hasattr(vl, "__len__") and len(vl) == 1):
-                            vl = vl[0]
-                        else:
+                if hasattr(node, "read"):
+                    vl = node.read()
+                    cont = True
+                    while cont:
+                        try:
+                            if not isinstance(vl, str) and \
+                               (hasattr(vl, "__len__") and len(vl) == 1):
+                                vl = vl[0]
+                            else:
+                                cont = False
+                        except Exception:
                             cont = False
-                    except Exception:
-                        cont = False
-                nd["value"] = vl
+                    nd["value"] = vl
             if "shape" in desc and desc["shape"] not in [None, [1], []]:
                 if "shape" in nd.keys():
                     shp = nd["shape"]

--- a/nxstools/nxsfileparser.py
+++ b/nxstools/nxsfileparser.py
@@ -150,27 +150,20 @@ class NXSFileParser(object):
 
         #: (:obj:`list` <:obj:`str` >) \
         #    nexus field attribute show names
-        self.attrs = [
-            "units",
-            "type",
-            "depends_on",
-            "transformation_type",
-            "vector",
-            "offset",
-            "NX_class",
-            "name",
-            "short_name",
-            # from nexdatas
-            "source_name",
-            "source_type",
-            "source",
-            "strategy",
+        self.attrs = None
+        #: (:obj:`list` <:obj:`str` >) \
+        #    nexus field attribute hidden names
+        self.hiddenattrs = [
+            "nexdatas_source",
+            "nexdatas_strategy"
         ]
         #: (:obj:`list` <:obj:`str` >) \
         #    nexus field attribute show names
         self.entryclasses = [
             "NXentry"
         ]
+        #: (:obj:`dict` <:obj:`str`, [:obj:`str, `any`] > >) \
+        #  attribute description
         self.attrdesc = {
             "nexus_type": ["type", str],
             "units": ["units", str],
@@ -178,6 +171,14 @@ class NXSFileParser(object):
             "trans_type": ["transformation_type", str],
             "trans_vector": ["vector", str],
             "trans_offset": ["offset", str],
+            "source_name": ["nexdatas_source", getdsname],
+            "source_type": ["nexdatas_source", getdstype],
+            "source": ["nexdatas_source", getdssource],
+            "strategy": ["nexdatas_strategy", str],
+        }
+        #: (:obj:`dict` <:obj:`str`, [:obj:`str, `any`] > >) \
+        #  metadata attribute description
+        self.mattrdesc = {
             "source_name": ["nexdatas_source", getdsname],
             "source_type": ["nexdatas_source", getdstype],
             "source": ["nexdatas_source", getdssource],
@@ -300,6 +301,12 @@ class NXSFileParser(object):
             try:
                 if name in dct.keys():
                     gr = dct[name]
+                    if not isinstance(gr, dict):
+                        nm = name + "_"
+                        while nm in dct.keys():
+                            nm = nm + "_"
+                        dct[nm] = gr
+                        gr = dct[name] = {}
                 else:
                     gr = dct[name] = {}
                 ch = node.open(nm[0])
@@ -333,6 +340,12 @@ class NXSFileParser(object):
                 name = node.name + self.group_postfix
                 if name in dct.keys():
                     gr = dct[name]
+                    if not isinstance(gr, dict):
+                        nm = name + "_"
+                        while nm in dct.keys():
+                            nm = nm + "_"
+                        dct[nm] = gr
+                        gr = dct[name] = {}
                 else:
                     gr = dct[name] = {}
                 ch = node.open(nm[0])
@@ -370,10 +383,29 @@ class NXSFileParser(object):
                 nd = dct[smname] = {"name": node.name}
             else:
                 smname = node.name + self.group_postfix
-                nd = dct[smname] = {}
+
+                if smname in dct.keys():
+                    nd = dct[smname]
+                    if not isinstance(nd, dict):
+                        nm = smname + "_"
+                        while nm in dct.keys():
+                            nm = nm + "_"
+                        dct[nm] = nd
+                        nd = dct[smname] = {}
+                else:
+                    nd = dct[smname] = {}
         else:
             smname = node.name
-            nd = dct[smname] = {}
+            if smname in dct.keys():
+                nd = dct[smname]
+                if not isinstance(nd, dict):
+                    nm = smname + "_"
+                    while nm in dct.keys():
+                        nm = nm + "_"
+                    dct[nm] = nd
+                    nd = dct[smname] = {}
+            else:
+                nd = dct[smname] = {}
         if hasattr(node, "dtype"):
             desc["dtype"] = str(node.dtype)
         if hasattr(node, "shape"):
@@ -381,14 +413,25 @@ class NXSFileParser(object):
         if hasattr(node, "attributes"):
             attrs = node.attributes
             anames = [at.name for at in attrs]
-            for key, vl in self.attrdesc.items():
-                if vl[0] in anames and key in self.attrs:
+            for key, vl in self.mattrdesc.items():
+                if vl[0] in anames and \
+                   (self.attrs is None or key in self.attrs) and \
+                   (self.hiddenattrs is None or key not in self.hiddenattrs):
                     nd[key] = vl[1](filewriter.first(attrs[vl[0]].read()))
 
-            for at in self.attrs:
-                if at in anames:
-                    if at in self.attrs and \
-                       at not in self.attrdesc.keys():
+            if self.attrs is not None:
+                for at in self.attrs:
+                    if at in anames:
+                        if at in self.attrs and \
+                           at not in self.mattrdesc.keys() and \
+                           (self.hiddenattrs is None or
+                                at not in self.hiddenattrs):
+                            nd[at] = filewriter.first(attrs[at].read())
+            else:
+                for at in anames:
+                    if at not in self.mattrdesc.keys() and \
+                       (self.hiddenattrs is None or
+                            at not in self.hiddenattrs):
                         nd[at] = filewriter.first(attrs[at].read())
 
         if not isinstance(node, filewriter.FTGroup):
@@ -408,6 +451,12 @@ class NXSFileParser(object):
                         cont = False
                 nd["value"] = vl
             if "shape" in desc and desc["shape"] not in [None, [1], []]:
+                if "shape" in nd.keys():
+                    shp = nd["shape"]
+                    nm = "shape" + "_"
+                    while nm in nd.keys():
+                        nm = nm + "_"
+                    nd[nm] = shp
                 nd["shape"] = desc["shape"]
         return smname
 
@@ -443,10 +492,7 @@ class NXSFileParser(object):
             try:
                 at = entry.attributes["NX_class"]
             except Exception:
-                pass
-            if at and (len(self.entryclasses) == 0 or
-                       filewriter.first(at.read()) in self.entryclasses):
+                at = None
+            if len(self.entryclasses) == 0 or \
+               at and (filewriter.first(at.read()) in self.entryclasses):
                 self.__parsemetaentry(entry, self.description)
-                # self.metadata = json.dumps(
-                #     self.__dctmetadata, cls=numpyEncoder)
-                # self.__filter()

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -20,4 +20,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.12.0"
+__version__ = "3.13.0"


### PR DESCRIPTION
It resolves #241 by 
- adding --hidden-attributes option to  nxsfileinfo metadata, 
- changing default value for --attribute options of nxsfileinfo metadata,
- making fixes for duplication names in nxsfileinfo metadata
- making  fixes for missing link data in nxsfileinfo metadata
