### PR TITLE
Issue 257: add --pid-with-filename and --beamtimeid options for nxsfileinfo metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2022-03-09 Jan Kotanski <jankotan@gmail.com>
 	* set endTime, description, startTime from nexus file
-	* add --pid-with-uuid options for nxsfileinfo
+	* add --pid-with-uuid option for nxsfileinfo
+	* add --pid-with-filename option for nxsfileinfo
+	* add --beamtimeid option for nxsfileinfo
 	* tagged as v3.15.0
 
 2022-03-01 Jan Kotanski <jankotan@gmail.com>

--- a/doc/nxsfileinfo.rst
+++ b/doc/nxsfileinfo.rst
@@ -102,14 +102,18 @@ Options:
    -e ENTRYCLASSES, --entry-classes ENTRYCLASSES
                         names of entry NX_class to be shown (separated by commas without spaces). If name is '' all groups are shown. The default: 'NXentry'
    -r, --raw-metadata    do not store NXentry as scientificMetadata
+   -p PID, --pid PID
+                        dataset pid
+   -i BEAMTIMEID, --beamtimeid BEAMTIMEID
+                        beamtime id
+   -u, --pid-with-uuid
+                        generate pid with uuid
+   -f, --pid-with-filename
+                        generate pid with file name
    -b BEAMTIMEMETA, --beamtime-meta BEAMTIMEMETA
                         beamtime metadata file
    -s SCIENTIFICMETA, --scientific-meta SCIENTIFICMETA
                         scientific metadata file
-   -p PID, --pid PID
-                        dataset pid
-   -u, --pid-with-uuid
-                        generate pid with uuid
    -o OUTPUT, --output OUTPUT
                         output scicat metadata file
    --h5py               use h5py module as a nexus reader

--- a/man/nxscollect.1
+++ b/man/nxscollect.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSCOLLECT" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSCOLLECT" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxscollect \- upload external images into NeXus/HDF5 file
 .

--- a/man/nxsconfig.1
+++ b/man/nxsconfig.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSCONFIG" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSCONFIG" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxsconfig \- read NeXus Configuration Server settings
 .

--- a/man/nxscreate.1
+++ b/man/nxscreate.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSCREATE" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSCREATE" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxscreate \- create NeXus Configuration component
 .

--- a/man/nxsdata.1
+++ b/man/nxsdata.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSDATA" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSDATA" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxsdata \- run NeXus Data Writer
 .

--- a/man/nxsetup.1
+++ b/man/nxsetup.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSETUP" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSETUP" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxsetup \- set NeXDaTaS Tango Server environment up
 .

--- a/man/nxsfileinfo.1
+++ b/man/nxsfileinfo.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSFILEINFO" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSFILEINFO" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxsfileinfo \- show metadata of the NeXus file
 .
@@ -178,19 +178,28 @@ field names of more dimensional datasets which value should be shown (separated 
 postfix to be added to NeXus group name. The default: \(aqParameters\(aq
 .TP
 .BI \-e \ ENTRYCLASSES\fR,\fB \ \-\-entry\-classes \ ENTRYCLASSES
-names of entry NX_class to be shown (separated by commas without spaces).If name is \(aq\(aq all groups are shown. The default: \(aqNXentry\(aq
+names of entry NX_class to be shown (separated by commas without spaces). If name is \(aq\(aq all groups are shown. The default: \(aqNXentry\(aq
 .TP
 .B \-r\fP,\fB  \-\-raw\-metadata
 do not store NXentry as scientificMetadata
+.TP
+.BI \-p \ PID\fR,\fB \ \-\-pid \ PID
+dataset pid
+.TP
+.BI \-i \ BEAMTIMEID\fR,\fB \ \-\-beamtimeid \ BEAMTIMEID
+beamtime id
+.TP
+.B \-u\fP,\fB  \-\-pid\-with\-uuid
+generate pid with uuid
+.TP
+.B \-f\fP,\fB  \-\-pid\-with\-filename
+generate pid with file name
 .TP
 .BI \-b \ BEAMTIMEMETA\fR,\fB \ \-\-beamtime\-meta \ BEAMTIMEMETA
 beamtime metadata file
 .TP
 .BI \-s \ SCIENTIFICMETA\fR,\fB \ \-\-scientific\-meta \ SCIENTIFICMETA
 scientific metadata file
-.TP
-.BI \-p \ PID\fR,\fB \ \-\-pid \ PID
-dataset pid
 .TP
 .BI \-o \ OUTPUT\fR,\fB \ \-\-output \ OUTPUT
 output scicat metadata file

--- a/man/nxstools.1
+++ b/man/nxstools.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "NXSTOOLS" "1" "Feb 28, 2022" "3.13" "NXSTools"
+.TH "NXSTOOLS" "1" "Mar 09, 2022" "3.15" "NXSTools"
 .SH NAME
 nxstools \- nxstools Documentation
 .
@@ -1626,19 +1626,28 @@ field names of more dimensional datasets which value should be shown (separated 
 postfix to be added to NeXus group name. The default: \(aqParameters\(aq
 .TP
 .BI \-e \ ENTRYCLASSES\fR,\fB \ \-\-entry\-classes \ ENTRYCLASSES
-names of entry NX_class to be shown (separated by commas without spaces).If name is \(aq\(aq all groups are shown. The default: \(aqNXentry\(aq
+names of entry NX_class to be shown (separated by commas without spaces). If name is \(aq\(aq all groups are shown. The default: \(aqNXentry\(aq
 .TP
 .B \-r\fP,\fB  \-\-raw\-metadata
 do not store NXentry as scientificMetadata
+.TP
+.BI \-p \ PID\fR,\fB \ \-\-pid \ PID
+dataset pid
+.TP
+.BI \-i \ BEAMTIMEID\fR,\fB \ \-\-beamtimeid \ BEAMTIMEID
+beamtime id
+.TP
+.B \-u\fP,\fB  \-\-pid\-with\-uuid
+generate pid with uuid
+.TP
+.B \-f\fP,\fB  \-\-pid\-with\-filename
+generate pid with file name
 .TP
 .BI \-b \ BEAMTIMEMETA\fR,\fB \ \-\-beamtime\-meta \ BEAMTIMEMETA
 beamtime metadata file
 .TP
 .BI \-s \ SCIENTIFICMETA\fR,\fB \ \-\-scientific\-meta \ SCIENTIFICMETA
 scientific metadata file
-.TP
-.BI \-p \ PID\fR,\fB \ \-\-pid \ PID
-dataset pid
 .TP
 .BI \-o \ OUTPUT\fR,\fB \ \-\-output \ OUTPUT
 output scicat metadata file
@@ -5324,7 +5333,11 @@ loader constructor
 .UNINDENT
 .INDENT 7.0
 .TP
-.B cre = {\(aqaccessGroups\(aq: [], \(aqclassification\(aq: [], \(aqcreatedAt\(aq: [], \(aqcreatedBy\(aq: [], \(aqcreationTime\(aq: [], \(aqdataFormat\(aq: [], \(aqdatasetName\(aq: [], \(aqdatasetlifecycle\(aq: [], \(aqhistory\(aq: [], \(aqinstrumentId\(aq: [], \(aqisPublished\(aq: [\(aqfalse\(aq], \(aqkeywords\(aq: [], \(aqlicense\(aq: [], \(aqnumberOfFiles\(aq: [], \(aqnumberOfFilesArchived\(aq: [], \(aqorcidOfOwner\(aq: \(aqORCID of owner https://orcid.org if available\(aq, \(aqownerGroup\(aq: [], \(aqpackedSize\(aq: [], \(aqpublisheddateId\(aq: [], \(aqsampleId\(aq: [], \(aqscientificMetadata\(aq: {}, \(aqsize\(aq: [], \(aqsourceFolderHost\(aq: [], \(aqtechniques\(aq: [], \(aqupdatedAt\(aq: [], \(aqupdatedBy\(aq: [], \(aqvalidationStatus\(aq: [], \(aqversion\(aq: []}
+.B copymap = {\(aqcreationTime\(aq: \(aqscientificMetadata.end_time.value\(aq, \(aqdescription\(aq: \(aqscientificMetadata.title.value\(aq, \(aqendTime\(aq: \(aqscientificMetadata.end_time.value\(aq}
+.UNINDENT
+.INDENT 7.0
+.TP
+.B cre = {\(aqaccessGroups\(aq: [], \(aqclassification\(aq: [], \(aqcreatedAt\(aq: [], \(aqcreatedBy\(aq: [], \(aqcreationTime\(aq: [], \(aqdataFormat\(aq: [], \(aqdatasetName\(aq: [], \(aqdatasetlifecycle\(aq: [], \(aqhistory\(aq: [], \(aqinstrumentId\(aq: [], \(aqisPublished\(aq: [\(aqfalse\(aq], \(aqkeywords\(aq: [], \(aqlicense\(aq: [], \(aqnumberOfFiles\(aq: [], \(aqnumberOfFilesArchived\(aq: [], \(aqorcidOfOwner\(aq: \(aqORCID of owner https://orcid.org if available\(aq, \(aqownerGroup\(aq: [], \(aqpackedSize\(aq: [], \(aqpublisheddataId\(aq: [], \(aqsampleId\(aq: [], \(aqscientificMetadata\(aq: {}, \(aqsize\(aq: [], \(aqsourceFolderHost\(aq: [], \(aqtechniques\(aq: [], \(aqupdatedAt\(aq: [], \(aqupdatedBy\(aq: [], \(aqvalidationStatus\(aq: [], \(aqversion\(aq: []}
 .UNINDENT
 .INDENT 7.0
 .TP
@@ -5338,6 +5351,27 @@ update metadata with dictionary
 .TP
 .B Parameters
 \fBmetadata\fP (\fI\%dict\fP <\fI\%str\fP, \fIany\fP>) \-\- metadata dictionary to merge in
+.TP
+.B Returns
+metadata dictionary
+.TP
+.B Return type
+\fI\%dict\fP <\fI\%str\fP, \fIany\fP>
+.UNINDENT
+.UNINDENT
+.INDENT 7.0
+.TP
+.B overwrite(metadata, cmap=None)
+overwrite metadata with dictionary
+.INDENT 7.0
+.TP
+.B Parameters
+.INDENT 7.0
+.IP \(bu 2
+\fBmetadata\fP (\fI\%dict\fP <\fI\%str\fP, \fIany\fP>) \-\- metadata dictionary to merge in
+.IP \(bu 2
+\fBcmap\fP (\fI\%dict\fP <\fI\%str\fP, \fI\%str\fP>) \-\- overwrite dictionary
+.UNINDENT
 .TP
 .B Returns
 metadata dictionary
@@ -5364,7 +5398,32 @@ metadata dictionary
 .UNINDENT
 .INDENT 7.0
 .TP
-.B strcre = {\(aqcreationLocation\(aq: \(aq/DESY/{facility}/{beamline}\(aq, \(aqtype\(aq: \(aqraw\(aq}
+.B strcre = {\(aqcreationLocation\(aq: \(aq/DESY/{facility}/{beamline}\(aq, \(aqisPublished\(aq: False, \(aqtype\(aq: \(aqraw\(aq}
+.UNINDENT
+.INDENT 7.0
+.TP
+.B updatepid(metadata, filename=None, puuid=False, pfname=False, beamtimeid=None)
+update pid metadata with dictionary
+.INDENT 7.0
+.TP
+.B Parameters
+.INDENT 7.0
+.IP \(bu 2
+\fBmetadata\fP (\fI\%dict\fP <\fI\%str\fP, \fIany\fP>) \-\- metadata dictionary to merge in
+.IP \(bu 2
+\fBfilename\fP (\fI\%str\fP) \-\- nexus filename
+.IP \(bu 2
+\fBpuuid\fP (\fI\%bool\fP) \-\- pid with uuid
+.IP \(bu 2
+\fBpfname\fP (\fI\%bool\fP) \-\- pid with file name
+.UNINDENT
+.TP
+.B Returns
+metadata dictionary
+.TP
+.B Return type
+\fI\%dict\fP <\fI\%str\fP, \fIany\fP>
+.UNINDENT
 .UNINDENT
 .UNINDENT
 .INDENT 0.0

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -2400,6 +2400,8 @@ For more help:
 
         for arg in args:
             filename = arg[0]
+            fdir, fname = os.path.split(filename)
+            fname, fext = os.path.splitext(fname)
             title = arg[1]
             beamtime = arg[2]
             insname = arg[3]
@@ -2410,14 +2412,18 @@ For more help:
             formula = arg[8]
 
             commands = [
-                ('nxsfileinfo metadata %s %s -a units,NX_class'
+                ('nxsfileinfo metadata %s %s -a units,NX_class '
+                 ' -i 12344321 --pid-with-filename'
                  % (filename, self.flags)).split(),
                 ('nxsfileinfo metadata %s %s  '
+                 ' --beamtimeid 12344321 '
                  '--attributes units,NX_class'
                  % (filename, self.flags)).split(),
                 ('nxsfileinfo metadata %s %s -a units,NX_class'
+                 ' --beamtimeid 12344321 -f'
                  % (filename, self.flags)).split(),
                 ('nxsfileinfo metadata %s %s --attributes units,NX_class'
+                 ' -i 12344321 '
                  % (filename, self.flags)).split(),
             ]
 
@@ -2453,7 +2459,7 @@ For more help:
 
                 nxsfile.close()
 
-                for cmd in commands:
+                for kk, cmd in enumerate(commands):
                     old_stdout = sys.stdout
                     old_stderr = sys.stderr
                     sys.stdout = mystdout = StringIO()
@@ -2472,7 +2478,8 @@ For more help:
                     # print(vl)
                     dct = json.loads(vl)
                     # print(dct)
-                    res = {'scientificMetadata':
+                    res = {'pid': '12344321/12345',
+                           'scientificMetadata':
                            {'NX_class': 'NXentry',
                             'name': 'entry12345',
                             'dataParameters': {'NX_class': 'NXdata'},
@@ -2498,7 +2505,13 @@ For more help:
                            'endTime': '%s' % arg[6],
                            'description': '%s' % arg[1],
                            }
-                    self.myAssertDict(dct, res)
+                    self.myAssertDict(dct, res, skip=['pid'])
+                    if kk % 2:
+                        self.assertEqual(
+                            dct["pid"], "12344321/12345")
+                    else:
+                        self.assertEqual(
+                            dct["pid"], "12344321/%s_12345" % fname)
             finally:
                 os.remove(filename)
 


### PR DESCRIPTION
It resolves #257 by adding Issue 257: add --pid-with-filename and --beamtimeid options for nxsfileinfo metadata