### PR TITLE
Issue 397: store NXclass attribute with NXentry only for --raw-metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2022-11-24 Jan Kotanski <jankotan@gmail.com>
 	* fix for depends_on field in beamstop template (#396)
-	* tagged as v3.33.2
+	* store NXclass attribute with NXentry only for --raw-metadata (#398)
+	* tagged as v3.34.0
 
 2022-11-23 Jan Kotanski <jankotan@gmail.com>
 	* check if emptyunits variable exists (#393)

--- a/nxstools/nxsfileparser.py
+++ b/nxstools/nxsfileparser.py
@@ -454,7 +454,9 @@ class NXSFileParser(object):
                        (self.hiddenattrs is None or
                             at not in self.hiddenattrs):
                         nd[at] = filewriter.first(attrs[at].read())
-
+            if self.scientific and "NX_class" in nd.keys() and \
+               nd["NX_class"] == "NXentry":
+                nd.pop("NX_class")
         if not isinstance(node, filewriter.FTGroup):
             if (node.name in self.valuestostore and node.is_valid) \
                or "shape" not in desc \

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.33.2"
+__version__ = "3.34.0"

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -2691,8 +2691,7 @@ For more help:
                     res = {'pid': '12344321/12345',
                            'techniques': ltech,
                            'scientificMetadata':
-                           {'NX_class': 'NXentry',
-                            'name': 'entry12345',
+                           {'name': 'entry12345',
                             'data': {'NX_class': 'NXdata'},
                             'end_time': {'value': '%s' % arg[6]},
                             'experiment_identifier': {'value': '%s' % arg[2]},
@@ -2884,8 +2883,7 @@ For more help:
                     res = {'pid': '12344321/12345',
                            'techniques': ltech,
                            'scientificMetadata':
-                           {'NX_class': 'NXentry',
-                            'name': 'entry12345',
+                           {'name': 'entry12345',
                             'experiment_description': {
                                 'value': desc
                             },
@@ -3389,8 +3387,7 @@ For more help:
                     self.assertEqual('', er)
                     dct = json.loads(vl)
                     res = {'scientificMetadata':
-                           {'NX_class': 'NXentry',
-                            'name': 'entry12345',
+                           {'name': 'entry12345',
                             'instrument_': 'duplicated',
                             'instrument': {
                                 'NX_class': 'NXinstrument'},
@@ -3635,7 +3632,6 @@ For more help:
                         "principalInvestigator": "robust.robust@robust.com",
                         "proposalId": "16171271",
                         "scientificMetadata": {
-                            "NX_class": "NXentry",
                             "beamtimeId": "16171271",
                             "DOOR_proposalId": "65300407",
                             "user_comments": "Awesome comment",
@@ -4082,7 +4078,6 @@ For more help:
                         "principalInvestigator": "robust.robust@robust.com",
                         "proposalId": "16171271",
                         "scientificMetadata": {
-                            "NX_class": "NXentry",
                             "beamtimeId": "16171271",
                             "DOOR_proposalId": "65300407",
                             "ScanCommand": "ascan mot01 0 10 10 0.1",


### PR DESCRIPTION
It resolves #397 by storing  NXclass attribute with NXentry only for --raw-metadata