### PR TITLE
add ndf as a nexus file format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-12-12 Jan Kotanski <jankotan@gmail.com>
+	* add ndf to nexus file extension lists (#417)
+	* fixes for missing fileformat (#417)
+	* tagged as v3.37.2
+
 2022-12-09 Jan Kotanski <jankotan@gmail.com>
 	* fix for older versions of nxsdatawriter when fileformat is not defined
 	* tagged as v3.37.1

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -1182,6 +1182,10 @@ class Metadata(Runner):
         nxsparser = None
         if not hasattr(options, "fileformat"):
             options.fileformat = ""
+        if not options.fileformat:
+            rt, ext = os.path.splitext(options.args[0])
+            if ext and len(ext) > 1 and ext.startswith("."):
+                options.fileformat = ext[1:]
         if root is not None:
             if options.fileformat in ['nxs', 'h5', 'nx', 'ndf']:
                 nxsparser = NXSFileParser(root)

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -1086,7 +1086,7 @@ class Metadata(Runner):
                 if ext and len(ext) > 1 and ext.startswith("."):
                     options.fileformat = ext[1:]
             try:
-                if options.fileformat in ['nxs', 'h5', 'nx', 'hdf5']:
+                if options.fileformat in ['nxs', 'h5', 'nx', 'ndf']:
                     nxfl = filewriter.open_file(
                         options.args[0], readonly=True,
                         writer=wrmodule)
@@ -1180,8 +1180,10 @@ class Metadata(Runner):
                                 usercopylist.append(line[:2])
         result = None
         nxsparser = None
+        if not hasattr(options, "fileformat"):
+            options.fileformat = ""
         if root is not None:
-            if options.fileformat in ['nxs', 'h5', 'nx', 'hdf5']:
+            if options.fileformat in ['nxs', 'h5', 'nx', 'ndf']:
                 nxsparser = NXSFileParser(root)
                 nxsparser.valuestostore = values
                 nxsparser.group_postfix = options.group_postfix

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -1182,7 +1182,7 @@ class Metadata(Runner):
         nxsparser = None
         if not hasattr(options, "fileformat"):
             options.fileformat = ""
-        if not options.fileformat:
+        if options.args and not options.fileformat:
             rt, ext = os.path.splitext(options.args[0])
             if ext and len(ext) > 1 and ext.startswith("."):
                 options.fileformat = ext[1:]

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.37.1"
+__version__ = "3.37.2"


### PR DESCRIPTION
It resolves #416 by adding `ndf` as a nexus file format. It also fixes issue for older nxsdatawriter.