### PR TITLE
Issue 436: do not create json for attachments without thumbnail

### DIFF
--- a/.ci/ubuntu20.04_py3/Dockerfile
+++ b/.ci/ubuntu20.04_py3/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 MAINTAINER DESY, Jan Kotanski <jankotan@gmail.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
+RUN sed -i 's|http://archive|http://de.archive|g' /etc/apt/sources.list
 RUN apt-get -qq update && apt-get -qq install -y libterm-readline-gnu-perl software-properties-common coreutils gnupg2 procps apt-utils curl apt-transport-https gnupg2 ca-certificates wget
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN curl -s http://repos.pni-hdri.de/debian_repo.pub.gpg  | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/debian-hdri-repo.gpg --import

--- a/.ci/ubuntu22.04_py3/Dockerfile
+++ b/.ci/ubuntu22.04_py3/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:jammy
 
 MAINTAINER DESY, Jan Kotanski <jankotan@gmail.com>
+RUN sed -i 's|http://archive|http://de.archive|g' /etc/apt/sources.list
 RUN apt-get -qq update && apt-get -qq install -y libterm-readline-gnu-perl software-properties-common coreutils gnupg2 procps apt-utils curl apt-transport-https gnupg2 ca-certificates wget
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2023-02-06 Jan Kotanski <jankotan@gmail.com>
 	* do not create json for attachments without thumbnail (#437)
+	* use first existing axis (#437)
 	* tagged as v3.40.2
 
 2023-01-31 Jan Kotanski <jankotan@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-06 Jan Kotanski <jankotan@gmail.com>
+	* do not create json for attachments without thumbnail (#437)
+	* tagged as v3.40.2
+
 2023-01-31 Jan Kotanski <jankotan@gmail.com>
 	* fix nxsfileinfo attachment help (#432)
 	* tagged as v3.40.1

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2220,7 +2220,8 @@ class Attachment(Runner):
                             result["thumbnail"] = self._plot1d(
                                 sdata, adata, xlabel, slabel, options.caption)
 
-        return json.dumps(
+        if "thumbnail" in result and result["thumbnail"]:
+            return json.dumps(
                 result, sort_keys=True, indent=4,
                 cls=numpyEncoder)
 
@@ -2301,24 +2302,28 @@ class Attachment(Runner):
                 signal = "data"
 
         if sgnode is not None:
-            dtshape = sgnode.shape
-            # print(dtshape)
-            # print(nxdata.names())
-            # print(signal)
-            # print(slabel)
-            # print(xlabel)
-            # print(ylabel)
-            if len(dtshape) == 1:
-                return self._nxsplot1d(
-                    sgnode, signal, axes, slabel, xlabel, ylabel,
-                    title, overwrite)
-            elif len(dtshape) == 2:
-                return self._nxsplot2d(
-                    sgnode, signal, slabel, title, overwrite)
+            try:
+                dtshape = sgnode.shape
+                dtsize = sgnode.size
+                # print(dtshape)
+                # print(nxdata.names())
+                # print(signal)
+                # print(slabel)
+                # print(xlabel)
+                # print(ylabel)
+                if len(dtshape) == 1 and dtsize > 1:
+                    return self._nxsplot1d(
+                        sgnode, signal, axes, slabel, xlabel, ylabel,
+                        title, overwrite)
+                elif len(dtshape) == 2 and dtsize > 1:
+                    return self._nxsplot2d(
+                        sgnode, signal, slabel, title, overwrite)
 
-            elif len(dtshape) == 3:
-                return self._nxsplot3d(
-                    sgnode, signal, slabel, title, overwrite, frame)
+                elif len(dtshape) == 3 and dtsize > 1:
+                    return self._nxsplot3d(
+                        sgnode, signal, slabel, title, overwrite, frame)
+            except Exception:
+                return None
 
     def _nxsplot3d(self, sgnode, signal, slabel, title,
                    overwrite=False, frame=None):

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2207,11 +2207,16 @@ class Attachment(Runner):
                                 sdata = nxsparser.columns[0][1]
                                 if not slabel:
                                     slabel = nxsparser.columns[0][0]
-                        if data and axes and axes[0] in data.keys():
-                            adata = data[axes[0]]
-                            if not xlabel:
-                                xlabel = axes[0]
-                        elif len(nxsparser.columns) > 1 and \
+                        axis = None
+                        if data and axes:
+                            for ax in axes:
+                                if ax and ax in data.keys():
+                                    axis = ax
+                                    adata = data[ax]
+                                    if not xlabel:
+                                        xlabel = ax
+
+                        if not axis and len(nxsparser.columns) > 1 and \
                                 len(nxsparser.columns[0]) > 1:
                             adata = nxsparser.columns[0][1]
                             if not xlabel:
@@ -2455,9 +2460,15 @@ class Attachment(Runner):
                 axes = [naxes]
         adata = []
         anode = None
-        if axes and axes[0] in nxdata.names():
-            anode = nxdata.open(axes[0])
-            adata = anode.read()
+        if axes:
+            for ax in axes:
+                if ax in nxdata.names():
+                    try:
+                        anode = nxdata.open(ax)
+                        adata = anode.read()
+                        break
+                    except Exception:
+                        pass
         sdata = sgnode.read()
         sunits = None
         aunits = None

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.40.1"
+__version__ = "3.40.2"

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -9155,7 +9155,7 @@ For more help:
                 "0o666",
                 "0666",
                 "exp_c03",
-                "exp_mot04",
+                "ex_mo1,exp_mot04",
                 "exp_c03.(counts)",
                 "lat.(mm)",
             ],
@@ -9420,7 +9420,7 @@ For more help:
                 "0o662",
                 "0662",
                 "exp_c99,exp_c02",
-                "timestamp",
+                "erd,timestamp",
                 "exp_p02.(counts)",
                 "time.(s)",
             ],
@@ -9539,7 +9539,6 @@ For more help:
                     ctn = tn[len("data:image/png;base64,"):]
 
                     ipng = base64.b64decode(ctn.encode("utf-8"))
-
                     img = PIL.Image.open(BytesIO(ipng))
                     shape = np.array(img).shape
                     self.assertEqual(len(shape), 3)
@@ -9712,7 +9711,6 @@ For more help:
                     ctn = tn[len("data:image/png;base64,"):]
 
                     ipng = base64.b64decode(ctn.encode("utf-8"))
-
                     img = PIL.Image.open(BytesIO(ipng))
                     shape = np.array(img).shape
                     self.assertEqual(len(shape), 3)

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -9045,9 +9045,10 @@ For more help:
             er = mystderr.getvalue()
 
             self.assertEqual('', er)
-            dct = json.loads(vl)
-            res = {}
-            self.myAssertDict(dct, res)
+            self.assertEqual('', vl.strip())
+            # dct = json.loads(vl)
+            # res = {}
+            # self.myAssertDict(dct, res)
 
     def test_attachment_png(self):
         """ test nxsfileinfo attachment
@@ -9318,7 +9319,6 @@ For more help:
             bid = arg[3]
             bl = arg[4]
             chmod = arg[5]
-            chmod2 = arg[6]
             signals = arg[7]
             axes = arg[8]
             slabel = arg[9]
@@ -9379,26 +9379,7 @@ For more help:
                     self.assertEqual('', er)
                     self.assertEqual('', vl.strip())
 
-                    with open(ofname) as of:
-                        dct = json.load(of)
-                        status = os.stat(ofname)
-                    try:
-                        self.assertEqual(
-                            chmod, str(oct(status.st_mode & 0o777)))
-                    except Exception:
-                        self.assertEqual(
-                            chmod2, str(oct(status.st_mode & 0o777)))
-                    res = {
-                        'id': atid,
-                        'caption': caption,
-                        "ownerGroup": "%s-dmgt" % bid,
-                        "accessGroups": [
-                            '%s-clbt' % bid,
-                            '%s-part' % bid,
-                            '%s-dmgt' % bid,
-                            '%sdmgt' % bl, '%sstaff' % bl],
-                    }
-                    self.myAssertDict(dct, res)
+                    self.assertTrue(not os.path.isfile(ofname))
 
             finally:
                 if os.path.isfile(filename):


### PR DESCRIPTION
It resolves #436 by do not creating  json for attachments without thumbnail and using first existing axis in nxsfileinfo attachment