### PR TITLE
Issue 442: take next axis if the first does not exist in nxsfileinfo attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-07 Jan Kotanski <jankotan@gmail.com>
+	* take next axis if the first does not exist in nxsfileinfo attribute (#443)
+	* tagged as v3.40.4
+
 2023-02-06 Jan Kotanski <jankotan@gmail.com>
 	* change --overwrite to --override in nxsfileinfo attachment (#440)
 	* tagged as v3.40.3

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2460,11 +2460,13 @@ class Attachment(Runner):
                 axes = [naxes]
         adata = []
         anode = None
+        axis = ""
         if axes:
             for ax in axes:
                 if ax in nxdata.names():
                     try:
                         anode = nxdata.open(ax)
+                        axis = ax
                         adata = anode.read()
                         break
                     except Exception:
@@ -2495,8 +2497,8 @@ class Attachment(Runner):
         if (not override or not xlabel) and axes and axes[0]:
             if alname:
                 xlabel = alname
-            elif not xlabel:
-                xlabel = axes[0]
+            elif not xlabel and axis:
+                xlabel = axis
             if aunits:
                 xlabel = "%s (%s)" % (xlabel, aunits)
         if (not override or not title) and nxdata.parent is not None and \

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.40.3"
+__version__ = "3.40.4"


### PR DESCRIPTION
It resolves #442 by taking  next axis if the first does not exist in nxsfileinfo attribute