### PR TITLE
Issue 456: use suptitle to title and title for scancmd in nxsfileinfo attachment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 2023-02-22 Jan Kotanski <jankotan@gmail.com>
-	* add scan_command to the title in nxsfileinfo attribute (#457)
+	* add scan_command to the title in nxsfileinfo attribute (#457), (#458)
 	* tagged as v3.42.0
 
 2023-02-16 Jan Kotanski <jankotan@gmail.com>

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2751,10 +2751,6 @@ class Attachment(Runner):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
-        # if axis is not None and len(axis) == len(data):
-        #     ax.plot(axis, data, 'o', axis, data)
-        #     ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
-        # else:
         shape = data.shape
         if int(shape[0]/shape[1]) > maxratio or \
                 int(shape[1]/shape[0]) > maxratio:
@@ -2767,11 +2763,6 @@ class Attachment(Runner):
                 title = "%s: %s" % (title, slabel)
             else:
                 title = slabel
-        # if scancmd:
-        #     if title:
-        #         title = "%s\n%s" % (title, scancmd)
-        #     else:
-        #         title = scancmd
 
         if title:
             fig.suptitle(title, fontsize=20, y=1)

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2692,38 +2692,32 @@ class Attachment(Runner):
 
         if ylabel:
             if title:
-                title = "%s: %s" % (title, ylabel)
+                title = title
             else:
                 title = ylabel
-        if scancmd:
-            if title:
-                title = "%s\n%s" % (title, scancmd)
-            else:
-                title = scancmd
 
         if axis is not None and len(axis) == len(data):
             if len(data) < maxo:
                 ax.plot(axis, data, 'o', axis, data)
             else:
                 ax.plot(axis, data)
-            ax.set(xlabel=xlabel, ylabel=ylabel, title=title)
+            ax.set(xlabel=xlabel, ylabel=ylabel, title=scancmd)
             if xlabel:
                 pars["xlabel"] = xlabel
-            if ylabel:
-                pars["ylabel"] = ylabel
-            if title:
-                pars["title"] = title
         else:
             axis = list(range(len(data)))
             if len(data) < maxo:
                 ax.plot(axis, data, 'o', axis, data)
             else:
                 ax.plot(axis, data)
-            ax.set(ylabel=ylabel, title=title)
-            if ylabel:
-                pars["ylabel"] = ylabel
-            if title:
-                pars["title"] = title
+            ax.set(ylabel=ylabel, title=scancmd)
+        fig.suptitle(title, fontsize=20, y=1)
+        if ylabel:
+            pars["ylabel"] = ylabel
+        if title:
+            pars["suptitle"] = title
+        if scancmd:
+            pars["title"] = scancmd
 
         buffer = BytesIO()
         plt.savefig(buffer, format='png')
@@ -2773,15 +2767,18 @@ class Attachment(Runner):
                 title = "%s: %s" % (title, slabel)
             else:
                 title = slabel
-        if scancmd:
-            if title:
-                title = "%s\n%s" % (title, scancmd)
-            else:
-                title = scancmd
+        # if scancmd:
+        #     if title:
+        #         title = "%s\n%s" % (title, scancmd)
+        #     else:
+        #         title = scancmd
 
         if title:
-            ax.set(title=title)
-            pars["title"] = title
+            fig.suptitle(title, fontsize=20, y=1)
+            pars["suptitle"] = title
+        if scancmd:
+            ax.set(title=scancmd)
+            pars["title"] = scancmd
 
         buffer = BytesIO()
         plt.savefig(buffer, format='png')

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -9197,11 +9197,11 @@ For more help:
                 "exp_c03.(counts)",
                 "lat.(mm)",
                 '{"xlabel": "exp_mot04", "ylabel": "exp_c03", '
-                '"title": "My_tests: exp_c03'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "lat.(mm)", "ylabel": "exp_c03.(counts)", '
-                '"title": "My_tests: exp_c03.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests", '
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
             ],
             [
                 "mymeta2_00011.fio",
@@ -9216,11 +9216,11 @@ For more help:
                 "exp_p02.(counts)",
                 "time.(s)",
                 '{"xlabel": "timestamp", "ylabel": "exp_c02", '
-                '"title": "Water_tests: exp_c02'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
-                '"title": "Water_tests: exp_p02.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
             ],
         ]
 
@@ -9356,11 +9356,11 @@ For more help:
                 "exp_c03.(counts)",
                 "lat.(mm)",
                 '{"xlabel": "timestamp", "ylabel": "exp_c03", '
-                '"title": "My_tests: exp_c03'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "lat.(mm)", "ylabel": "exp_c03.(counts)", '
-                '"title": "My_tests: exp_c03.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"ascan":"exp_mot01;timestamp;exp_mot04"}',
             ],
             [
@@ -9376,11 +9376,11 @@ For more help:
                 "exp_p02.(counts)",
                 "time.(s)",
                 '{"xlabel": "timestamp", "ylabel": "exp_c03", '
-                '"title": "Water_tests: exp_c03'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
-                '"title": "Water_tests: exp_p02.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"ascan":"exp_mot01;timestamp;exp_mot04"}',
             ],
         ]
@@ -9515,11 +9515,11 @@ For more help:
                 "exp_c03.(counts)",
                 "lat.(mm)",
                 '{"xlabel": "exp_mot04", "ylabel": "exp_c03", '
-                '"title": "My_tests: exp_c03'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "lat.(mm)", "ylabel": "exp_c03.(counts)", '
-                '"title": "My_tests: exp_c03.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
             ],
             [
                 "mymeta2_00011.fio",
@@ -9534,11 +9534,11 @@ For more help:
                 "exp_p02.(counts)",
                 "time.(s)",
                 '{"xlabel": "exp_mot04", "ylabel": "exp_c03", '
-                '"title": "Water_tests: exp_c03'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
-                '"title": "Water_tests: exp_p02.(counts)'
-                '\\nascan exp_mot04 0.0 4.0 4 0.5"}',
+                '"suptitle": "Water_tests",'
+                '"title": "ascan exp_mot04 0.0 4.0 4 0.5"}',
             ],
         ]
 
@@ -9785,9 +9785,9 @@ For more help:
                 "exp_c03.(counts)",
                 "lat.(mm)",
                 '{"xlabel": "exp_mot04", "ylabel": "exp_c03", '
-                '"title": "My_tests: exp_c03"}',
+                '"suptitle": "My_tests"}',
                 '{"xlabel": "lat.(mm)", "ylabel": "exp_c03.(counts)", '
-                '"title": "My_tests: exp_c03.(counts)"}',
+                '"suptitle": "My_tests"}',
             ],
             [
                 'testfileinfo.nxs',
@@ -9804,9 +9804,9 @@ For more help:
                 "exp_p02.(counts)",
                 "time.(s)",
                 '{"xlabel": "timestamp", "ylabel": "exp_c02", '
-                '"title": "Water_tests: exp_c02"}',
+                '"suptitle": "Water_tests"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
-                '"title": "Water_tests: exp_p02.(counts)"}',
+                '"suptitle": "Water_tests"}',
             ],
         ]
 
@@ -9965,11 +9965,11 @@ For more help:
                 "exp_c03.(counts)",
                 "lat.(mm)",
                 '{"xlabel": "timestamp (s)", "ylabel": "exp_c02 (counts)", '
-                '"title": "My_tests: exp_c02 (counts)'
-                '\\nascan timestamp 0 1 10 0.1"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan timestamp 0 1 10 0.1"}',
                 '{"xlabel": "lat.(mm)", "ylabel": "exp_c03.(counts)", '
-                '"title": "My_tests: exp_c03.(counts)'
-                '\\nascan timestamp 0 1 10 0.1"}',
+                '"suptitle": "My_tests",'
+                '"title": "ascan timestamp 0 1 10 0.1"}',
                 'ascan timestamp 0 1 10 0.1',
             ],
             [
@@ -9987,11 +9987,11 @@ For more help:
                 "exp_p02.(counts)",
                 "time.(s)",
                 '{"xlabel": "exp_mot04 (mm)", "ylabel": "exp_c02 (counts)", '
-                '"title": "Water_tests: exp_c02 (counts)'
-                '\\nqscan exp_mot04 0 1 10 0.1"}',
+                '"suptitle": "Water_tests",'
+                '"title": "qscan exp_mot04 0 1 10 0.1"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
-                '"title": "Water_tests: exp_p02.(counts)'
-                '\\nqscan exp_mot04 0 1 10 0.1"}',
+                '"suptitle": "Water_tests",'
+                '"title": "qscan exp_mot04 0 1 10 0.1"}',
                 'qscan exp_mot04 0 1 10 0.1',
             ],
         ]
@@ -10154,8 +10154,8 @@ For more help:
                 "exp_mot04",
                 "MCA01",
                 "lat.(mm)",
-                '{"aspect":"auto","title":"My_tests: exp_mca01"}',
-                '{"aspect":"auto","title":"My_tests: MCA01"}',
+                '{"aspect":"auto","suptitle":"My_tests: exp_mca01"}',
+                '{"aspect":"auto","suptitle":"My_tests: MCA01"}',
             ],
             [
                 'testfileinfo.nxs',
@@ -10171,8 +10171,8 @@ For more help:
                 "timestamp",
                 "MCA01",
                 "time.(s)",
-                '{"aspect":"auto","title":"Water_tests: exp_mca01"}',
-                '{"aspect":"auto","title":"Water_tests: MCA01"}',
+                '{"aspect":"auto","suptitle":"Water_tests: exp_mca01"}',
+                '{"aspect":"auto","suptitle":"Water_tests: MCA01"}',
             ],
         ]
 
@@ -10339,8 +10339,8 @@ For more help:
                 "exp_mot04",
                 "MCA01",
                 3,
-                '{"title": "My_tests: lambda"}',
-                '{"title": "My_tests: lambda"}',
+                '{"suptitle": "My_tests: lambda"}',
+                '{"suptitle": "My_tests: lambda"}',
             ],
             [
                 'testfileinfo.nxs',
@@ -10356,8 +10356,8 @@ For more help:
                 "timestamp",
                 "MCA01",
                 2,
-                '{"title": "Water_tests: lambda"}',
-                '{"title": "Water_tests: lambda"}',
+                '{"suptitle": "Water_tests: lambda"}',
+                '{"suptitle": "Water_tests: lambda"}',
             ],
         ]
 


### PR DESCRIPTION
It improves #457 by using suptitle to title and title for scancmd in nxsfileinfo attachment