### PR TITLE
Issue 470: split a scan command text in the dataset attachment if it is too long

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2023-02-27 Jan Kotanski <jankotan@gmail.com>
+	* split a scan command text in the dataset attachment if it is too long (#471)
+	* tagged as v3.42.4
+
+2023-02-27 Jan Kotanski <jankotan@gmail.com>
 	* move left, right, top, bottom of NXslit to the NXtransformations (#469)
 	* tagged as v3.42.3
 

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2710,7 +2710,7 @@ class Attachment(Runner):
             sdata, adata, xlabel, slabel, title, scancmd=scancmd)
 
     def _plot1d(self, data, axis, xlabel, ylabel, title, maxo=25,
-                scancmd=None):
+                scancmd=None, maxtitle=68):
         """ create oned thumbnail plot
 
 
@@ -2728,6 +2728,8 @@ class Attachment(Runner):
         :type maxo: :obj:`int`
         :param scancmd: scan command
         :type scancmd: :obj:`str`
+        :param maxtitle: maximal title size
+        :type maxtitle: :obj:`int`
         :returns: thumbnail string
         :rtype: :obj:`str`
         """
@@ -2738,9 +2740,9 @@ class Attachment(Runner):
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
 
-        if scancmd and len(scancmd) > 68:
+        if scancmd and len(scancmd) > maxtitle:
             # scancmd = splittext(scancmd)
-            scancmd = scancmd[:68]
+            scancmd = scancmd[:maxtitle]
         if ylabel:
             if title:
                 title = title
@@ -2780,7 +2782,8 @@ class Attachment(Runner):
         thumbnail = "data:image/png;base64," + thumbnail.decode('utf-8')
         return thumbnail, json.dumps(pars)
 
-    def _plot2d(self, data, slabel, title, maxratio=10, scancmd=None):
+    def _plot2d(self, data, slabel, title, maxratio=10, scancmd=None,
+                maxtitle=68):
         """ create oned thumbnail plot
 
 
@@ -2794,6 +2797,8 @@ class Attachment(Runner):
         :type maxratio: :obj:`float`
         :param scancmd: scan command
         :type scancmd: :obj:`str`
+        :param maxtitle: maximal title size
+        :type maxtitle: :obj:`int`
         :returns: thumbnail string
         :rtype: :obj:`str`
         """
@@ -2809,8 +2814,8 @@ class Attachment(Runner):
             pars["aspect"] = 'auto'
         else:
             ax.imshow(data)
-        if scancmd and len(scancmd) > 68:
-            scancmd = scancmd[:68]
+        if scancmd and len(scancmd) > maxtitle:
+            scancmd = scancmd[:maxtitle]
             # scancmd = splittext(scancmd)
         if slabel:
             if title:

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -87,6 +87,36 @@ def getlist(text):
     return lst
 
 
+def splittext(text, lmax=68):
+    """ split text to lines
+
+    :param text: parser options
+    :type text: :obj:`str`
+    :param lmax: maximal line length
+    :type lmax: :obj:`int`
+    :returns: split text
+    :rtype: :obj:`str`
+    """
+    lnew = []
+
+    lw = [" " + ee for ee in text.split(" ") if ee]
+    nw = []
+    for ew in lw:
+        ww = [ee + "," for ee in ew.split(",") if ee]
+        ww[-1] = ww[-1][:-1]
+        nw.extend(ww)
+
+    for ll in nw:
+        if ll:
+            if not lnew and ll[1:]:
+                lnew.append(ll[1:])
+            elif len(lnew[-1]) + len(ll) < lmax:
+                lnew[-1] = lnew[-1] + ll
+            else:
+                lnew.append(ll)
+    return "\n".join(lnew)
+
+
 class General(Runner):
 
     """ General runner"""
@@ -2708,6 +2738,8 @@ class Attachment(Runner):
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
 
+        if scancmd and len(scancmd) > 68:
+            scancmd = splittext(scancmd)
         if ylabel:
             if title:
                 title = title
@@ -2776,6 +2808,8 @@ class Attachment(Runner):
             pars["aspect"] = 'auto'
         else:
             ax.imshow(data)
+        if scancmd and len(scancmd) > 68:
+            scancmd = splittext(scancmd)
         if slabel:
             if title:
                 title = "%s: %s" % (title, slabel)

--- a/nxstools/nxsfileinfo.py
+++ b/nxstools/nxsfileinfo.py
@@ -2739,7 +2739,8 @@ class Attachment(Runner):
         fig, ax = plt.subplots()
 
         if scancmd and len(scancmd) > 68:
-            scancmd = splittext(scancmd)
+            # scancmd = splittext(scancmd)
+            scancmd = scancmd[:68]
         if ylabel:
             if title:
                 title = title
@@ -2809,7 +2810,8 @@ class Attachment(Runner):
         else:
             ax.imshow(data)
         if scancmd and len(scancmd) > 68:
-            scancmd = splittext(scancmd)
+            scancmd = scancmd[:68]
+            # scancmd = splittext(scancmd)
         if slabel:
             if title:
                 title = "%s: %s" % (title, slabel)

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.42.3"
+__version__ = "3.42.4"

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -10003,15 +10003,11 @@ For more help:
                 '{"xlabel": "exp_mot04 (mm)", "ylabel": "exp_c02 (counts)", '
                 '"suptitle": "Water_tests",'
                 '"title": "qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 '
-                '0.1 qscan\\n exp_mot04 0 1 10 0.1 '
-                '[tango,\\ntango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'
-                '/p00/nnnnnnnnn/sdfsdf/sdf]"}',
+                '0.1 qscan exp_mot0"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
                 '"suptitle": "Water_tests",'
                 '"title": "qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 '
-                '0.1 qscan\\n exp_mot04 0 1 10 0.1 '
-                '[tango,\\ntango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'
-                '/p00/nnnnnnnnn/sdfsdf/sdf]"}',
+                '0.1 qscan exp_mot0"}',
                 'qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 0.1 '
                 'qscan exp_mot04 0 1 10 0.1 '
                 '[tango,tango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'

--- a/test/NXSFileInfo_test.py
+++ b/test/NXSFileInfo_test.py
@@ -10002,11 +10002,20 @@ For more help:
                 "time.(s)",
                 '{"xlabel": "exp_mot04 (mm)", "ylabel": "exp_c02 (counts)", '
                 '"suptitle": "Water_tests",'
-                '"title": "qscan exp_mot04 0 1 10 0.1"}',
+                '"title": "qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 '
+                '0.1 qscan\\n exp_mot04 0 1 10 0.1 '
+                '[tango,\\ntango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'
+                '/p00/nnnnnnnnn/sdfsdf/sdf]"}',
                 '{"xlabel": "time.(s)", "ylabel": "exp_p02.(counts)", '
                 '"suptitle": "Water_tests",'
-                '"title": "qscan exp_mot04 0 1 10 0.1"}',
-                'qscan exp_mot04 0 1 10 0.1',
+                '"title": "qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 '
+                '0.1 qscan\\n exp_mot04 0 1 10 0.1 '
+                '[tango,\\ntango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'
+                '/p00/nnnnnnnnn/sdfsdf/sdf]"}',
+                'qscan exp_mot04 0 1 10 0.1 qscan exp_mot04 0 1 10 0.1 '
+                'qscan exp_mot04 0 1 10 0.1 '
+                '[tango,tango://myyyyyyyyyyyyyyyyyyyyyyyyy.desy.de'
+                '/p00/nnnnnnnnn/sdfsdf/sdf]',
             ],
         ]
 
@@ -10129,6 +10138,8 @@ For more help:
                     cps = dct["caption"].split(" ", 1)
                     self.assertEqual(len(cps), 2)
                     self.assertEqual(cps[0], caption)
+                    # print(json.loads(cps[1]))
+                    # print(json.loads(pars))
                     self.myAssertDict(json.loads(cps[1]), json.loads(pars))
 
                     tn = dct["thumbnail"]


### PR DESCRIPTION
It resolves #470 by splitting  a scan command text in the dataset attachment if it is too long