### PR TITLE
Issue 518: fix the order of secop meaning by the highest importance

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-10-25 Jan Kotanski <jankotan@gmail.com>
+	* fix order of secop meaning by highest importance (#519)
+	* tagged as v3.50.1
+
 2023-10-09 Jan Kotanski <jankotan@gmail.com>
 	* add support for data filter list (#516)
 	* tagged as v3.50.0

--- a/nxstools/nxscreator.py
+++ b/nxstools/nxscreator.py
@@ -1932,7 +1932,7 @@ class SECoPCPCreator(CPCreator):
                 created.append(mn)
 
         llinks = sorted([(tg, mns[0], mns[1]) for tg, mns in links.items()],
-                        key=itemgetter(2))
+                        key=itemgetter(2), reverse=True)
 
         for target, mn, semn in llinks:
             starget = target.split("/")

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.50.0"
+__version__ = "3.50.1"


### PR DESCRIPTION
It resolves #518 by fixing the order of secop meaning by the highest importance