### PR TITLE
Issue 536: add support for unit and other attributes in FIOFileParser

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-12-13 Jan Kotanski <jankotan@gmail.com>
+	* add support for unit and other attributes in FIOFileParser (#534)
+	* tagged as v3.54.0
+
 2023-11-28 Jan Kotanski <jankotan@gmail.com>
 	* add --copy-map-error to nxsfileinfo metadata (#534)
 	* add --group-map-error to nxsfileinfo metadata (#534)

--- a/nxstools/nxsfileparser.py
+++ b/nxstools/nxsfileparser.py
@@ -659,12 +659,33 @@ class FIOFileParser(object):
                 sline = line.split("=")
                 if len(sline) > 1 and sline[0].strip() and \
                    sline[1].strip():
-                    try:
-                        params[sline[0].strip().replace(" ", "_")] = \
-                            eval(sline[1].strip())
-                    except Exception:
-                        params[sline[0].strip().replace(" ", "_")] = \
-                            str(sline[1].strip())
+                    if '@' not in sline[0]:
+                        try:
+                            params[sline[0].strip().replace(" ", "_")] = \
+                                eval(sline[1].strip())
+                        except Exception:
+                            params[sline[0].strip().replace(" ", "_")] = \
+                                str(sline[1].strip())
+        for line in lines:
+            if not line.startswith("!") and "=" in line:
+                sline = line.split("=")
+                if len(sline) > 1 and sline[0].strip() and \
+                   sline[1].strip():
+                    if '@' in sline[0]:
+                        field, attr = sline[0].strip().replace(" ", "_"). \
+                            split("@")[:2]
+                        try:
+                            avl = eval(sline[1].strip())
+                        except Exception:
+                            avl = str(sline[1].strip())
+
+                        if field in params:
+                            if not isinstance(params[field], dict):
+                                params[field] = {"value": params[field]}
+                            if attr in ["unit", "units"]:
+                                params[field]["unit"] = avl
+                            else:
+                                params[field][attr] = avl
 
         if params:
             meta["parameters"] = params

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.53.0"
+__version__ = "3.54.0"


### PR DESCRIPTION
It resolves #536 by adding support for unit and other attributes in FIOFileParser