### PR TITLE
Issue 551: fix convention for entry names in multi-scan NeXus files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-12-19 Jan Kotanski <jankotan@gmail.com>
+	* fix convention for entry names in multi-scan NeXus files (#552)
+	* tagged as v3.55.1
+
 2023-12-15 Jan Kotanski <jankotan@gmail.com>
 	* add support for fetching metadata from multi-scan Nexus files (#542)
 	* add --nexus-path option to nxsfileinfo attachment (#544)

--- a/nxstools/pyeval/scdataset.py
+++ b/nxstools/pyeval/scdataset.py
@@ -89,7 +89,7 @@ def append_scicat_dataset(macro, status_info=True):
         if not nexus or appendentry is False:
             sname = "%s_%05i" % (scanname, sid)
         else:
-            sname = "%s::/%s%05i;%s_%05i" % (
+            sname = "%s::/%s%i;%s_%05i" % (
                 scanname, entryname, sid, scanname, sid)
 
         # auto grouping

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "3.55.0"
+__version__ = "3.55.1"


### PR DESCRIPTION
It resolves #551 by fixing convention for entry names in multi-scan NeXus files