### PR TITLE
Issue 795: add missing triggered_devices for flint 2.2.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-09-24 Jan Kotanski <jankotan@gmail.com>
+	* add missing triggered_devices for flint 2.2.1 (#796)
+	* tagged as v4.27.1
+
 2025-09-18 Jan Kotanski <jankotan@gmail.com>
 	* add support for blissdata 2 and pydantic 2 (#793)
 	* tagged as v4.27.0

--- a/nxstools/h5rediswriter.py
+++ b/nxstools/h5rediswriter.py
@@ -662,11 +662,13 @@ class H5RedisFile(H5File):
         #     ["axis"])
         self.set_devices(
             DeviceDict(
+                name="time", channels=[], metadata={},
+                triggered_devices=["mg_channels", "observables"]),
+            ["time"])
+        self.set_devices(
+            DeviceDict(
                 name="mg_channels", channels=[], metadata={}),
             ["mg_channels"])
-        self.set_devices(
-            DeviceDict(name="time", channels=[], metadata={}),
-            ["time"])
         self.set_devices(
             DeviceDict(
                 name="observables", channels=[], metadata={}),

--- a/nxstools/release.py
+++ b/nxstools/release.py
@@ -19,4 +19,4 @@
 """  NXS tools release version"""
 
 #: (:obj:`str`) package version
-__version__ = "4.27.0"
+__version__ = "4.27.1"


### PR DESCRIPTION
It resolves #795