### PR TITLE
Prepare next lima acquisition for lima devices with tango url

### DIFF
--- a/nxstools/h5rediswriter.py
+++ b/nxstools/h5rediswriter.py
@@ -90,10 +90,12 @@ LimaStream = None
 try:
     from blissdata.streams.lima.stream import LimaStream
     from blissdata.lima.client import acquisition_on_server
+    from blissdata.lima.client import prepare_next_lima_acquisition
     PLUGINS["lima"] = LimaStream
 except Exception:
     LimaStream = None
     acquisition_on_server = None
+    prepare_next_lima_acquisition = None
 
 try:
     from blissdata.schemas.scan_info import (
@@ -518,6 +520,17 @@ class H5RedisFile(H5File):
         """
         if acquisition_on_server is not None:
             return acquisition_on_server(self.__datastore, server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if prepare_next_lima_acquisition is not None:
+            return prepare_next_lima_acquisition(self.__datastore, server_url)
 
     def set_scan(self, scan):
         """ scan object
@@ -1129,6 +1142,17 @@ class H5RedisGroup(H5Group):
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
 
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
+
     def set_entryname(self, entryname):
         """ set entry name
 
@@ -1458,6 +1482,17 @@ class H5RedisField(H5Field):
         """
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
 
     def set_scan(self, scan):
         """ scan object
@@ -2017,6 +2052,15 @@ class H5RedisVirtualFieldLayout(H5VirtualFieldLayout):
                     print("Cannot read acquisition_on_server for",
                           vmap, str(e))
                 try:
+                    if vmap["plugin"] == "lima" and \
+                            "server_url" in plugin_def and \
+                            plugin_def["server_url"]:
+                        self.prepare_next_lima_acquisition(
+                            plugin_def["server_url"])
+                except Exception as e:
+                    print("Cannot prepare_next_lima_acquisition for",
+                          vmap, str(e))
+                try:
                     sdef = plugin.make_definition(**plugin_def)
                     # print("create", plugin_def)
                     self.__rstream = self.scan_command(
@@ -2112,6 +2156,17 @@ class H5RedisVirtualFieldLayout(H5VirtualFieldLayout):
         """
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
 
     def scan_command(self, command, *args, **kwargs):
         """ set scan attribute

--- a/nxstools/rediswriter.py
+++ b/nxstools/rediswriter.py
@@ -67,10 +67,12 @@ LimaStream = None
 try:
     from blissdata.streams.lima.stream import LimaStream
     from blissdata.lima.client import acquisition_on_server
+    from blissdata.lima.client import prepare_next_lima_acquisition
     PLUGINS["lima"] = LimaStream
 except Exception:
     LimaStream = None
     acquisition_on_server = None
+    prepare_next_lima_acquisition = None
 
 try:
     from blissdata.schemas.scan_info import (
@@ -790,6 +792,17 @@ class RedisFile(filewriter.FTFile):
         """
         if acquisition_on_server is not None:
             return acquisition_on_server(self.__datastore, server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if prepare_next_lima_acquisition is not None:
+            return prepare_next_lima_acquisition(self.__datastore, server_url)
 
     def set_scan(self, scan):
         """ scan object
@@ -1623,6 +1636,17 @@ class RedisGroup(filewriter.FTGroup):
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
 
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
+
     def set_entryname(self, entryname):
         """ set entry name
 
@@ -2065,6 +2089,17 @@ class RedisField(filewriter.FTField):
         """
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
 
     def set_scan(self, scan):
         """ scan object
@@ -3161,6 +3196,15 @@ class RedisVirtualFieldLayout(filewriter.FTVirtualFieldLayout):
                     print("Cannot read acquisition_on_server for",
                           vmap, str(e))
                 try:
+                    if vmap["plugin"] == "lima" and \
+                            "server_url" in plugin_def and \
+                            plugin_def["server_url"]:
+                        self.prepare_next_lima_acquisition(
+                            plugin_def["server_url"])
+                except Exception as e:
+                    print("Cannot prepare_next_lima_acquisition for",
+                          vmap, str(e))
+                try:
                     sdef = plugin.make_definition(**plugin_def)
                     # print("create", plugin_def)
                     self.__rstream = self.scan_command(
@@ -3256,6 +3300,17 @@ class RedisVirtualFieldLayout(filewriter.FTVirtualFieldLayout):
         """
         if hasattr(self._tparent, "acquisition_on_server"):
             return self._tparent.acquisition_on_server(server_url)
+
+    def prepare_next_lima_acquisition(self, server_url):
+        """ prepare the next lima acquisition on the server
+
+        :param server_url: server url
+        :typeserver_url: :obj:`str`
+        :returns: next acquisition number
+        :rtype: :obj:`int`
+        """
+        if hasattr(self._tparent, "prepare_next_lima_acquisition"):
+            return self._tparent.prepare_next_lima_acquisition(server_url)
 
     def scan_command(self, command, *args, **kwargs):
         """ set scan attribute


### PR DESCRIPTION
## Summary

Adds `prepare_next_lima_acquisition(data_store, server_url)` support, mirroring the existing `acquisition_on_server` mechanism, in both `rediswriter.py` and `h5rediswriter.py`.

- Imports `prepare_next_lima_acquisition` from `blissdata.lima.client` (with a `None` fallback when blissdata lima support is unavailable).
- Adds the real implementation on the root file class (using `self.__datastore`) plus forwarding methods on the group / field / virtual-field-layout classes, exactly matching the `acquisition_on_server` delegation chain.
- Calls it in `append_vmap` at `frame == 0`, **guarded so it only runs for lima devices that have their tango url** (`vmap["plugin"] == "lima"` and `plugin_def["server_url"]`), so the redis acquisition counter is incremented once per lima device per scan.

## Notes

The call is invoked for its side effect (incrementing the per-`server_url` redis counter that prepares the next lima acquisition); the returned acquisition number is not currently consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)